### PR TITLE
Skip connection shutdown if not connected

### DIFF
--- a/omero_scripts/omero_basics.py
+++ b/omero_scripts/omero_basics.py
@@ -91,8 +91,9 @@ class OMEROConnectionManager:
 
     def disconnect(self):
         ''' Terminate the OMERO Connection '''
-        self.conn.seppuku(softclose=True)
-        self.conn = None
+        if self.conn:
+            self.conn.seppuku(softclose=True)
+            self.conn = None
 
     def hql_query(self, query, params=None):
         ''' Execute the given HQL query and return the results. Optionally


### PR DESCRIPTION
OMEROConnectionManager.conn was None if the connection failed, causing the
destructor to fail when trying to close the connection.